### PR TITLE
Configured RestTemplate for https links

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/src/main/java/com/codedrills/CodeDrillsApplication.java
+++ b/src/main/java/com/codedrills/CodeDrillsApplication.java
@@ -1,8 +1,12 @@
 package com.codedrills;
 
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
 
@@ -12,7 +16,12 @@ public class CodeDrillsApplication {
 
   @Bean
   public RestTemplate restTemplate() {
-    return new RestTemplate();
+    CloseableHttpClient httpClient = HttpClients.custom()
+            .setSSLHostnameVerifier(new NoopHostnameVerifier())
+            .build();
+    HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+    requestFactory.setHttpClient(httpClient);
+    return new RestTemplate(requestFactory);
   }
 
   public static void main(String[] args) {


### PR DESCRIPTION
Fixing 403 errors for `https://` codeforces api links. 
Tested in local that analysis for codeforces usernames are working.